### PR TITLE
style: improve text display for path and filename

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -539,6 +539,8 @@ h3 { font-size: 1.68rem; }
 
 .tag { display: inline-block; border: #e0e0e099 1px solid; padding: 0 4px 0 4px; margin: 1px 3px; border-radius: 5px; font-size: 12px !important; vertical-align: middle; background: #2d4a69; white-space: nowrap !important; overflow: hidden !important; text-overflow: ellipsis !important; }
 
+.tag.multiline { white-space: normal !important; overflow: visible !important; overflow-wrap: anywhere; word-break: break-word; max-width: 100%; display: block; line-height: 1.25; }
+
 .tag.warp { white-space: normal !important; overflow: visible !important; }
 
 .tag.second { background: #4a4a4a; }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -570,6 +570,16 @@ $spac: ($pad * 2) + ($gx * 2) + $sideW + 10px;
 	overflow: hidden !important;
 	text-overflow: ellipsis !important;
 
+	&.multiline {
+		white-space: normal !important;
+		overflow: visible !important;
+		overflow-wrap: anywhere;
+		word-break: break-word;
+		max-width: 100%;
+		display: block;
+		line-height: 1.25;
+	}
+
 	&.warp {
 		white-space: normal !important;
 		overflow: visible !important;

--- a/src/ui/cards.py
+++ b/src/ui/cards.py
@@ -143,12 +143,11 @@ def mk(ass: models.Asset, modSim=True):
                 ], className="RB")
             ], className="viewer"),
             dbc.CardBody([
-
                 dbc.Row([
                     htm.Span("id"), htm.Span(f"{ass.id}", className="tag"),
                     htm.Span("device"), htm.Span(f"{ass.deviceId}", className="tag second"),
-                    htm.Span("File"), htm.Span(f"{ass.originalFileName}", className="tag second"),
-                    htm.Span("Path"), htm.Span(f"{ass.originalPath}", className="tag second"),
+                    htm.Span("File"), htm.Span(f"{ass.originalFileName}", className="tag second multiline"),
+                    htm.Span("Path"), htm.Span(f"{ass.originalPath}", className="tag second multiline"),
                     htm.Span("CreateAt"), htm.Span(f"{ass.fileCreatedAt}", className="tag second"),
 
                     *([ htm.Span("livePhoto"), htm.Span(f"{ass.pathVdo}", className="tag blue"), ] if isLive else []),


### PR DESCRIPTION
Show the full file name and full path in text boxes.
For me comparing paths is essential while going through duplicates from my external library.

Before:
<img width="263" height="407" alt="mediakit-wihnachte-vor-css" src="https://github.com/user-attachments/assets/a754b3b5-69ec-42ea-888e-469e1d529ce2" />

After:
<img width="256" height="431" alt="mediakit-weihnachten-danach" src="https://github.com/user-attachments/assets/45622bca-f7ee-42cc-9bf7-384577bdecba" />

I compiled the .css from the .scss and hope I did everything right. Feel free to do whatever you want with this PR